### PR TITLE
Expand on the spec draft

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -76,9 +76,9 @@ Side note: GL binding referred to in step 3. is an interface that is newly intro
 
 ## Obtaining camera extrinsics and intrinsics
 
-Some Computer Vision algorithms may depend on camera intrinsics and extrinsics in order to correctly perform. The camera extrinsics can be obtained by inspecting the `XRView`'s `transform` attribute (this is relative to the reference space used to obtain the viewer pose). The camera intrinsics can be computed given a projection matrix returned from an `XRView`, as well as `XRViewport`. Below, we will go through 2 different paths of calculating the transformation from camera space coordinates to screen space coordinates - one relying on projection matrix and viewport properties, the other relying on camera intrinsics matrix - and use the known parameters from the former approach to calculate the unknown parameters for latter calculation method.
+Some Computer Vision algorithms may depend on camera intrinsics and extrinsics. The camera extrinsics can be obtained by inspecting the `XRView`'s `transform` attribute (this is relative to the reference space used to obtain the viewer pose). The camera intrinsics can be computed given a projection matrix returned from an `XRView`, as well as `XRViewport`. Below, we will go through 2 different paths of calculating the transformation from camera space coordinates to screen space coordinates - one relying on projection matrix and viewport properties, the other relying on camera intrinsics matrix - and use the known parameters from the former approach to calculate the unknown parameters for latter calculation method.
 
-**Note:** The steps to obtain camera intrinsics and extrinsics are only valid since the camera image returned by the API is perfectly aligned with the `XRView` from which it was obtained.
+**Note:** The steps to obtain camera intrinsics and extrinsics are based on the assumption that the camera image returned by the API is perfectly aligned with the `XRView` from which it was obtained. Raw camera access API guarantees that this assumption holds, but the calculations will not be valid for more general scenarios.
 
 ### Camera space to screen space - projection matrix and viewport route
 
@@ -145,7 +145,7 @@ K = ax  gamma  u0  0
     0   0      1   0
 ```
 
-For compatibility with WebXR, insert a placeholder 3rd row to get a 4x4 matrix `Kexp` and invert the Z coordinate. This produces a modified intrinsic matrix K':
+For compatibility with WebXR, create a 4x4 matrix `Kexp` from `K` by inserting a placeholder 3rd row. (The values in this row don't affect the intrinsic parameter calculation and are marked by * .) Then invert the Z coordinate to produce a modified intrinsic matrix `K'`:
 
 ```
 K' = 1  0  0  0 * Kexp = ax  gamma -u0  0

--- a/explainer.md
+++ b/explainer.md
@@ -74,6 +74,147 @@ const cameraTexture = binding.getCameraImage(view.camera);
 
 Side note: GL binding referred to in step 3. is an interface that is newly introduced in the [WebXR Layers Module](https://immersive-web.github.io/layers/#XRWebGLBindingtype). It can be [constructed](https://immersive-web.github.io/layers/#dom-xrwebglbinding-xrwebglbinding) given an `XRSession` and `XRWebGLRenderingContext`.
 
+## Obtaining camera extrinsics and intrinsics
+
+Some Computer Vision algorithms may depend on camera intrinsics and extrinsics in order to correctly perform. The camera extrinsics can be obtained by inspecting the `XRView`'s `transform` attribute (this is relative to the reference space used to obtain the viewer pose). The camera intrinsics can be computed given a projection matrix returned from an `XRView`, as well as `XRViewport`. Below, we will go through 2 different paths of calculating the transformation from camera space coordinates to screen space coordinates - one relying on projection matrix and viewport properties, the other relying on camera intrinsics matrix - and use the known parameters from the former approach to calculate the unknown parameters for latter calculation method.
+
+**Note:** The steps to obtain camera intrinsics and extrinsics are only valid since the camera image returned by the API is perfectly aligned with the `XRView` from which it was obtained.
+
+### Camera space to screen space - projection matrix and viewport route
+
+Projection matrix convetions as per: http://www.songho.ca/opengl/gl_projectionmatrix.html.
+
+Starting from a projection matrix with the following parameters:
+
+```
+P = p0  p4  p8   p12
+    p1  p5  p9   p13
+    p2  p6  p10  p14
+    p3  p7  p11  p15
+```
+
+We can repeat the derivation of the projection matrix from [songho.ca](http://www.songho.ca/opengl/gl_projectionmatrix.html), allowing for non-zero skew:
+
+```
+P = p0  p4  p8   0    = 2n/(r-l)  skew      (r+l)/(r-l)  0
+    0   p5  p9   0      0         2n/(t-b)  (t+b)/(t-b)  0
+    0   0   p10  p14    0         0        -(f+n)/(f-n) -2fn/(f-n)
+    0   0  -1    0      0         0        -1            0
+```
+
+The skew factor controls how much of the Y coordinate is mixed into the X coordinate. It is usually zero, but WebXR allows nonzero skew values which results in nonrectangular pixels.
+
+A GL projection matrix transforms from camera space to clip space, then to NDC after perspective divide. This needs to be scaled to pixels based on the viewport `vp`. The NDC x and y ranges `(-1 .. 1)` are then transformed to `(vp.x .. vp.x + vp.width)` and `(vp.y .. vp.y + vp.height)`, respectively. For example, NDC x coordinate is transformed to screen space:
+
+```
+screen_x = vp.w * (ndc_x + 1)/2 + vp.x
+         = (vp.w/2) * ndc_x + (vp.w/2 + vp.x)
+```
+
+Using a matrix S for the NDC-to-screen-coordinate transform described above, this becomes:
+
+```
+p_screen.xy = (S * p_ndc).xy
+
+with S = vp.w/2  0       0  vp.w/2 + vp.x
+         0       vp.h/2  0  vp.h/2 + vp.y
+         0       0       1  0
+         0       0       0  1
+```
+
+The camera-space point transformation into screen space is then as follows:
+
+```
+p_screen.xy = (S * p_ndc).xy
+            = (S * p_clip).xy / p_clip.w
+            = (S * P * p_camera).xy / (P * p_camera).w
+            = (S * P * p_camera).xy / (-p_camera.z)
+```
+
+Note that this uses the usual GL convention of looking along the negative Z axis, with negative-z points being visible.
+
+### Camera space to screen space - intrinsic matrix route
+
+Intrinsic matrix convention as per https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters
+
+The intrinsic matrix K transforms from camera space to homogenous screen space, providing pixel screen coordinates after the perspective divide. This convention assumes looking along the positive Z axis, with positive-z points being visible.
+
+```
+K = ax  gamma  u0  0
+    0   ay     v0  0
+    0   0      1   0
+```
+
+For compatibility with WebXR, insert a placeholder 3rd row to get a 4x4 matrix `Kexp` and invert the Z coordinate. This produces a modified intrinsic matrix K':
+
+```
+K' = 1  0  0  0 * Kexp = ax  gamma -u0  0
+     0  1  0  0          0   ay    -v0  0
+     0  0 -1  0          *   *      *   *
+     0  0  0  1          0   0     -1   0
+```
+
+This results in the following transformation from camera space to screen space:
+
+```
+p_screen.xy = (K' * p_camera).xy / (K' * p_camera).w
+            = (K' * p_camera).xy / (-p_camera.z)
+```
+
+### Putting it together
+
+Since the `p_screen.xy` coordinates must be the same for both calculation methods, it
+follows that the intrinsic matrix K' is S * P:
+
+```
+p_screen.xy = (K' * p_camera).xy / (-p_camera.z)
+            = (S * P * p_camera).xy / (-p_camera.z)
+
+=>
+  K' = S * P
+```
+
+For example, K'[0,2] is -u0, and equals the product of row 0 of S with column 2 of P:
+
+```
+K'[0,2] = S[0,] * P[,2]
+    -u0 = [vp.v/2, 0, 0, vp.w/2 + vp.x] * [p8, p9, p10, -1]
+        = (vp.w/2) * p8 + 0 * p9 + 0 * p10 + (vp.w/2 + vp.x) * (-1)
+        = vp.w/2 * (p8 - 1) - vp.x
+
+=>
+  u0 = vp.w/2 * (1 - p8) + vp.x
+```
+
+Repeating the calculation for other intrinsic matrix parameters, we arrive at the following function:
+
+```javascript
+function getCameraIntrinsics(projectionMatrix, viewport) {
+  const p = projectionMatrix;
+
+  // Principal point in pixels (typically at or near the center of the viewport)
+  let u0 = (1 - p[8]) * viewport.width / 2 + viewport.x;
+  let v0 = (1 - p[9]) * viewport.height / 2 + viewport.y;
+
+  // Focal lengths in pixels (these are equal for square pixels)
+  let ax = viewport.width / 2 * p[0];
+  let ay = viewport.height / 2 * p[5];
+
+  // Skew factor in pixels (nonzero for rhomboid pixels)
+  let gamma = viewport.width / 2 * p[4];
+
+  // Print the calculated intrinsics:
+  const intrinsicString = (
+    "intrinsics: u0=" + u0 + " v0=" + v0 + " ax=" + ax + " ay=" + ay +
+    " gamma=" + gamma + " for viewport {width=" +
+    viewport.width + ",height=" + viewport.height + ",x=" +
+    viewport.x + ",y=" + viewport.y + "}");
+
+  console.log("projection:", Array.from(projectionMatrix).join(", "));
+  console.log(intrinsicString);
+}
+```
+
 ## Alternatives considered
 
 ### Initial API proposal

--- a/index.bs
+++ b/index.bs
@@ -26,6 +26,9 @@ spec: WebGL; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/
     type: interface; text: WebGLTexture; url: 5.9
 spec: WebXR Layers; urlPrefix: https://immersive-web.github.io/layers/#
     type: dfn; text: opaque texture; url: opaque-texture
+    for: XRWebGLBinding;
+        type: dfn; text: context; url: xrwebglbinding-context
+        type: dfn; text: session; url: xrwebglbinding-session
 spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
     type: dfn; text: capable of supporting; url: capable-of-supporting
     type: dfn; text: feature descriptor; url: feature-descriptor
@@ -40,8 +43,10 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
     for: XRSession;
         type: dfn; text: mode; url: xrsession-mode
         type: dfn; text: XR device; url: xrsession-xr-device
+        type: dfn; text: requestAnimationFrame()
     for: XRView;
         type: dfn; text: frame; url: xrview-frame
+        type: dfn; text: session; url: xrview-session
     type: dfn; text: XR device; url: xr-device
     for: XR device;
         type: dfn; text: list of enabled features; url: xr-device-list-of-enabled-features
@@ -105,6 +110,10 @@ Introduction {#intro}
 
 <section class="non-normative">
 
+This specification introduces new WebXR Device API capability, namely Raw Camera Access API. The newly introduced API enables WebXR-powered applications to access camera image pixels, allowing them to leverage this new information to compute custom per-frame visual effects, or take a snapshot of the app-rendered content overlaid with the camera image.
+
+Note: The API shape specified in this document primarily solves the smartphone-centric scenarios. See <a href="https://github.com/immersive-web/raw-camera-access/issues/2">issue #2</a> for context.
+
 </section>
 
 Terminology {#terminology}
@@ -118,7 +127,7 @@ Initialization {#initialization}
 Feature descriptor {#feature-descriptor}
 ------------------
 
-The applications can request that raw camera access be enabled on an XRSession by passing an appropriate [=feature descriptor=]. This module introduces new string - <dfn>camera-access</dfn>, as a new valid feature descriptor for raw camera access feature.
+The applications can request that raw camera access be enabled on an {{XRSession}} by passing an appropriate [=feature descriptor=]. This module introduces new string - <dfn>camera-access</dfn>, as a new valid feature descriptor for raw camera access feature.
 
 A device is [=capable of supporting=] the raw camera access feature if the device exposes [=native camera=] capability. The [=inline XR device=] MUST NOT be treated as [=capable of supporting=] the raw camera access feature.
 
@@ -136,7 +145,7 @@ const session = await navigator.xr.requestSession("immersive-ar", {
 </div>
 
 Accessing camera texture {#accessing-camera-texture}
-====================
+========================
 
 XRView {#xr-view-section}
 ------
@@ -146,6 +155,25 @@ partial interface XRView {
   [SameObject] readonly attribute XRCamera? camera;
 };
 </script>
+
+The {{XRView}} is extended to contain a {{XRView/camera}} attribute which refers to an {{XRCamera}} instance containing information about the camera image that can be obtained for the view. When {{XRView/camera}} attribute is accessed for the first time on a given {{XRView} instance, the user agent MUST run the [=obtain camera=] algorithm. Subsequent accesses on the same {{XRView}} instance MUST result the same {{XRCamera}} instance if one was returned, or <code>null</code>.
+
+<div class="algorithm" data-algorithm="obtain-camera">
+
+In order to <dfn>obtain camera</dfn> for {{XRView}} |view|, the user agent MUST run the following steps:
+
+  1. Let |session| be the |view|'s [=XRView/session=].
+  1. Let |device| be the |session|'s [=XRSession/XR device=].
+  1. If [=camera-access=] feature descriptor is not [=list/contain|contained=] in the |device|'s [=XR device/list of enabled features=] for |session|'s [=XRSession/mode=], return <code>null</code> and abort these steps.
+  1. Let |frame| be the |view|'s [=XRView/frame=].
+  1. If |frame|'s [=XRFrame/active=] boolean is <code>false</code>, [=exception/throw=] an {{InvalidStateError}} and abort these steps.
+  1. If |frame|'s [=XRFrame/animationFrame=] boolean is <code>false</code>, [=exception/throw=] an {{InvalidStateError}} and abort these steps.
+  1. Let |camera image| contain a camera image buffer of size |width| by |height| texels that was returned from [=native camera=] that is valid for |frame|'s [=XRFrame/time=].
+  1. If |camera image| is <code>null</code>, return <code>null</code> and abort these steps.
+  1. Ensure that |camera image| contains data that is [=aligned=] with the |view|, including adjusting |width| and |height| as appropriate. If that is not possible, return <code>null</code> and abort these steps.
+  1. Invoke [=create camera instance=] algorithm with |view|, |camera image|, |width| and |height| and return its result.
+
+</div>
 
 XRCamera {#xr-camera-section}
 --------
@@ -158,6 +186,28 @@ interface XRCamera {
 };
 </script>
 
+The {{XRCamera}} interface is introduced as a way to expose information about the camera texture that can be obtained from {{XRWebGLBinding}}.
+
+The {{XRCamera}} contains {{XRCamera/width}} attribute that contains the width (in texels) of the [=XRCamera/camera image=].
+
+The {{XRCamera}} contains {{XRCamera/height}} attribute that contains the height (in texels) of the [=XRCamera/camera image=].
+
+Each {{XRCamera}} has an associated <dfn for=XRCamera>view</dfn> instance that contains the {{XRView}} from which the {{XRCamera}} instance was returned.
+
+Each {{XRCamera}} has an associated <dfn for=XRCamera>camera image</dfn> data buffer.
+
+<div class="algorithm" data-algorithm="create-camera">
+In order to <dfn> create camera instance</dfn> from {{XRView}} |view|, |camera image|, |width| and |height|, the user agent MUST run the following steps:
+
+  1. Let |result| be a new instance of {{XRCamera}} interface.
+  1. Set |result|'s [=XRCamera/view=] to |view|.
+  1. Set |result|'s [=XRCamera/camera image=] to |camera image|.
+  1. Set |result|'s {{XRCamera/width}} to |width|.
+  1. Set |result|'s {{XRCamera/height}} to |height|.
+  1. Return |result|.
+
+</div>
+
 XRWebGLBinding {#xr-web-gl-binding-section}
 --------------
 
@@ -167,24 +217,56 @@ partial interface XRWebGLBinding {
 };
 </script>
 
+The {{XRWebGLBinding/getCameraImage(camera)}} method, when invoked, can be used to [=obtain camera image=] from an {{XRWebGLBinding}}. The returned {{WebGLTexture}}, if non-<code>null</code>, is an [=opaque texture=].
+
+<div class="algorithm" data-algorithm="obtain-camera-image">
+In order to <dfn>obtain camera image</dfn> from {{XRWebGLBinding}} |binding|, for {{XRCamera}} |camera|, the user agent MUST run the following steps:
+
+  1. Let |session| be |binding|'s [=XRWebGLBinding/session=].
+  1. Let |view| be |camera|'s [=XRCamera/view=].
+  1. If |view|'s [=XRView/session=] does not match |session|, [=exception/throw=] an {{InvalidStateError}} and abort these steps.
+  1. Let |frame| be the |view|'s [=XRView/frame=].
+  1. If |frame|'s [=XRFrame/active=] boolean is <code>false</code>, [=exception/throw=] an {{InvalidStateError}} and abort these steps.
+  1. If |frame|'s [=XRFrame/animationFrame=] boolean is <code>false</code>, [=exception/throw=] an {{InvalidStateError}} and abort these steps.
+  1. Let |context| be the |binding|'s [=XRWebGLBinding/context=].
+  1. Let |camera image| be the |camera|'s [=XRCamera/camera image=].
+  1. Let |result| be a {{WebGLTexture}} that was created on |context|, containing |camera image|'s data.
+  1. Return |result|.
+
+</div>
+
+The user agent MAY cache the results of a call to {{XRWebGLBinding/getCameraImage(camera)}} to be returned for subsequent calls of the method, assuming that the cache is keyed by the binding and the camera instance. The user agent MUST still validate perform initial validations even when using the cache by running up to step 6 (inclusive) of [=obtain camera image=] algorithm. Because this caching is permitted, the application SHOULD treat the returned {{WebGLTexture}} as read-only.
+
+Note: caching is permitted because the user agent retains ownership of the lifetime of the returned {{WebGLTexture}} (since it's considered an [=opaque texture=]), and because calling this method multiple times within the same [=requestAnimationFrame()=] callback (ensured by using {{XRCamera}}, & therefore {{XRFrame}} transitively as a part of the cache key), on the same binding (ensured by using {{XRWebGLBinding}} as a part of the cache key), will result in textures with identical contents.
+
+Issue: Should we specify more information about the returned {{WebGLTexture}}? E.g.: is color-renderable, what is the texture format, etc.
+
 Native device concepts {#native-device-concepts} 
 ======================
 
-Native camera {#native-camera}
+Native camera {#native-camera-section}
 -------------
 
 <section class="non-normative">
 
+Raw camera API specification assumes that the native device on top of which the API is implemented provides a way to access animation-frame-synchronized access to the camera image. Such a device is said to support a <dfn>native camera</dfn> capability.
+
+In addition for the device to being able to provide a camera image, the Raw Camera Access API can only provide camera image textures that are [=aligned=] with an {{XRView}} from which they are requested. The camera image is said to be <dfn>aligned</dfn> with the {{XRView}} if the camera pose is the same as the {{XRView}}'s pose, and the camera's viewing frustum has the same shape as {{XRView}}'s viewing frustum. If the camera image returned by the [=native camera=] covers a viewing frustum that entirely contains the {{XRView}}'s viewing frustum, the user agent can crop the camera image as long as the operation causes the viewing frustum shapes to match exactly.
+
 </section>
+
+Issue: Do we want to allow the texture to be "uncropped", i.e. enlarged and filled with transparent texels in areas that would not contain the data coming from the camera?
 
 Privacy & Security Considerations {#privacy-security}
 =================================
 
 <section class="non-normative">
 
+The Raw Camera Access API has the highest privacy implications out of all currently available WebXR capabilities, in that it is the only API that allows the applications to directly observe the user's environment. Due to this, the user agents SHOULD seek user consent prior to allowing creating sessions with [=camera-access=] feature enabled. In addition, the application developers are strongly encouraged not to ask for [=camera-access=] feature if there are other means of achieving their use cases.
+
 </section>
 
 Acknowledgements {#ack}
 ================
 
-The following individuals have contributed to the design of the WebXR Depth Sensing specification:
+The following individuals have contributed to the design of the WebXR Raw Camera Access specification:

--- a/index.bs
+++ b/index.bs
@@ -239,6 +239,8 @@ The user agent MAY cache the results of a call to {{XRWebGLBinding/getCameraImag
 
 Note: caching is permitted because the user agent retains ownership of the lifetime of the returned {{WebGLTexture}} (since it's considered an [=opaque texture=]), and because calling this method multiple times within the same [=requestAnimationFrame()=] callback (ensured by using {{XRCamera}}, & therefore {{XRFrame}} transitively as a part of the cache key), on the same binding (ensured by using {{XRWebGLBinding}} as a part of the cache key), will result in textures with identical contents.
 
+If the {{WebGLTexture}} returned from a call to {{XRWebGLBinding/getCameraImage(camera)}} supports transparency, it MUST contain colors with premultiplied alpha.
+
 Issue: Should we specify more information about the returned {{WebGLTexture}}? E.g.: is color-renderable, what is the texture format, etc.
 
 Native device concepts {#native-device-concepts} 
@@ -254,8 +256,6 @@ Raw camera API specification assumes that the native device on top of which the 
 In addition for the device to being able to provide a camera image, the Raw Camera Access API can only provide camera image textures that are [=aligned=] with an {{XRView}} from which they are requested. The camera image is said to be <dfn>aligned</dfn> with the {{XRView}} if the camera pose is the same as the {{XRView}}'s pose, and the camera's viewing frustum has the same shape as {{XRView}}'s viewing frustum. If the camera image returned by the [=native camera=] covers a viewing frustum that entirely contains the {{XRView}}'s viewing frustum, the user agent can crop the camera image as long as the operation causes the viewing frustum shapes to match exactly.
 
 </section>
-
-Issue: Do we want to allow the texture to be "uncropped", i.e. enlarged and filled with transparent texels in areas that would not contain the data coming from the camera?
 
 Privacy & Security Considerations {#privacy-security}
 =================================

--- a/security-privacy-questionnaire.md
+++ b/security-privacy-questionnaire.md
@@ -1,0 +1,110 @@
+# Security and Privacy Questionnaire
+
+This document answers the [W3C Security and Privacy
+Questionnaire](https://w3ctag.github.io/security-questionnaire/) for the
+WebXR Raw Camera Access Module specification.
+
+01.  What information might this feature expose to Web sites or other parties,
+     and for what purposes is that exposure necessary?
+
+This feature exposes camera image obtained from the camera(s) present on the users'
+device. The cameras that the data will be coming from will depend on the WebXR
+session type. Spec author(s) expect that the cameras will initially only be used
+for Augmented Reality sessions on smartphones or tablets.
+
+02.  Do features in your specification expose the minimum amount of information
+     necessary to enable their intended uses?
+
+Yes. There are scenarios which require exposing camera images. The WebXR
+specification attempts to cater all other scenarios by providing more
+privacy-preserving APIs such as Hit Test API.
+
+03.  How do the features in your specification deal with personal information,
+     personally-identifiable information (PII), or information derived from
+     them?
+
+The features do not attempt to collect PII from the user, although they will
+result in exposing the camera image to applications. The camera images may be used
+to extract user's PII. The specification mandates that user agents collect
+user consent prior to creating WebXR session with the features enabled.
+
+04.  How do the features in your specification deal with sensitive information?
+
+The features do not attempt to collect sensitive information about the user, 
+although they will result in exposing the camera image to applications. The camera
+images may be used to infer some sensitive information about the user. The
+specification mandates that user agents collect user consent prior to creating WebXR 
+session with the features enabled.
+
+05.  Do the features in your specification introduce new state for an origin
+     that persists across browsing sessions?
+
+Not explicitly. The specification mandates that user agents collect user consent 
+prior to creating WebXR session with the features enabled. Depending on the
+implementation, this consent may be persisted across browsing sessions.
+
+06.  Do the features in your specification expose information about the
+     underlying platform to origins?
+
+Not explicitly. The specification exposes information derived from camera image size.
+
+07.  Does this specification allow an origin to send data to the underlying
+     platform?
+
+No.
+
+08.  Do features in this specification enable access to device sensors?
+
+Yes - the features explicitly allow access to device's camera.
+
+09.  What data do the features in this specification expose to an origin? Please
+     also document what data is identical to data exposed by other features, in the
+     same or different contexts.
+
+The features expose access to camera image and its resolution. The same information
+could be exposed by getUserMedia() APIs.
+
+10.  Do features in this specification enable new script execution/loading
+     mechanisms?
+
+No.
+
+11.  Do features in this specification allow an origin to access other devices?
+
+No. The WebXR Device API already allows the origin to access XR hardware - this
+specification allows the origin to potentially access camera sensors of that
+hardware.
+
+12.  Do features in this specification allow an origin some measure of control over
+     a user agent's native UI?
+
+No.
+
+13.  What temporary identifiers do the features in this specification create or
+     expose to the web?
+
+None.
+
+14.  How does this specification distinguish between behavior in first-party and
+     third-party contexts?
+
+No.
+
+15.  How do the features in this specification work in the context of a browser’s
+     Private Browsing or Incognito mode?
+
+No difference in behavior.
+
+16.  Does this specification have both "Security Considerations" and "Privacy
+     Considerations" sections?
+
+Yes.
+    
+17.  Do features in your specification enable origins to downgrade default
+     security protections?
+
+No.
+    
+18.  What should this questionnaire have asked?
+
+N/A.


### PR DESCRIPTION
Also adds intrinsics computation to the explainer and Security & Privacy
questionnaire.

2 open issues inline in the spec:
- Should we specify more information about the returned WebGLTexture?
  E.g.: is color-renderable, what is the texture format, etc.
- Do we want to allow the texture to be "uncropped", i.e. enlarged and
  filled with transparent texels in areas that would not contain the
  data coming from the camera?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/raw-camera-access/pull/4.html" title="Last updated on Jun 23, 2021, 10:37 PM UTC (f09694d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/raw-camera-access/4/c2a0e37...f09694d.html" title="Last updated on Jun 23, 2021, 10:37 PM UTC (f09694d)">Diff</a>