### PR TITLE
Add disclaimer text and camera link

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -1,5 +1,7 @@
 # WebXR Raw Camera Access
 
+*Note: "Raw" in the context of this specification should be taken to mean "direct" not "RAW" as in the camera format.*
+
 ## Overview
 
 Currently, to protect user privacy, WebXR Device API does not provide a way to grant raw camera access to the sites. Additionally, alternative ways for sites to obtain raw camera access (`getUserMedia()` web API) are not going to provide the application pose-synchronized camera images that could be integrated with WebXR Device API. For some scenarios, this limitation may pose a significant barrier to adoption of WebXR.

--- a/index.bs
+++ b/index.bs
@@ -20,9 +20,13 @@ Abstract: This specification provides a means to access the raw camera image dis
 </pre>
 
 <pre class="link-defaults">
+spec:permissions-1;
+    type:dfn; text:powerful feature
 </pre>
 
 <pre class="anchors">
+spec: Media Capture and Streams; urlPrefix: https://www.w3.org/TR/mediacapture-streams/#
+    type: dfn; text: camera; url: dfn-camera
 spec: WebGL; urlPrefix: https://www.khronos.org/registry/webgl/specs/latest/1.0/#
     type: interface; text: WebGLTexture; url: 5.9
 spec: WebXR Layers; urlPrefix: https://immersive-web.github.io/layers/#
@@ -296,6 +300,8 @@ Some examples of interacting with the user directly are:
 2. Displaying a series of permission prompts that would take into consideration various levels of user consent needed in order to create a session with the requested and optional features provided by the application to {{XRSystem/requestSession()}} call.
 
 It is the intent of this specification to ensure that the user agent does not encourage app developers to ask for [=camera-access=] feature if the experience they want to provide does not absolutely require it. Due to privacy implications of the feature, user agents are allowed to introduce additional friction when a site asks for access to the camera images, with the hopes that this would incentivize the applications to not ask for the feature needlessly.
+
+User Agents SHOULD consider re-using permissions UI (or permissions granted to the origin already) for the [=powerful feature=] "[=camera=]".
 
 </section>
 

--- a/index.bs
+++ b/index.bs
@@ -301,7 +301,7 @@ Some examples of interacting with the user directly are:
 
 It is the intent of this specification to ensure that the user agent does not encourage app developers to ask for [=camera-access=] feature if the experience they want to provide does not absolutely require it. Due to privacy implications of the feature, user agents are allowed to introduce additional friction when a site asks for access to the camera images, with the hopes that this would incentivize the applications to not ask for the feature needlessly.
 
-User Agents SHOULD consider re-using permissions UI (or permissions granted to the origin already) for the [=powerful feature=] "[=camera=]".
+User Agents should consider re-using permissions UI (or permissions granted to the origin already) for the [=powerful feature=] "[=camera=]".
 
 </section>
 


### PR DESCRIPTION
PR #15 Left out a couple of edits I'd proposed in Issue #14, primarily the disclaimer about "Raw" and the non-normative text encouraging re-use of existing camera permission infrastructure.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/raw-camera-access/pull/16.html" title="Last updated on Aug 31, 2022, 9:05 PM UTC (1d544e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/raw-camera-access/16/978051e...1d544e8.html" title="Last updated on Aug 31, 2022, 9:05 PM UTC (1d544e8)">Diff</a>