### PR TITLE
Fix error for image tag and update link errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -21,7 +21,7 @@ Abstract: This specification provides a means to access the raw camera image dis
 </pre>
 
 <pre class="link-defaults">
-spec:permissions-1;
+spec:permissions;
     type:dfn; text:powerful feature
 </pre>
 
@@ -48,7 +48,7 @@ spec: WebXR Device API - Level 1; urlPrefix: https://www.w3.org/TR/webxr/#
         type: dfn; text: time; url: xrframe-time
     type: interface; text: XRSession; url: xrsession-interface
     for: XRSession;
-        type: dfn; text: ended
+        type: attribute; text: ended; url: xrsession-ended
         type: dfn; text: mode; url: xrsession-mode
         type: dfn; text: XR device; url: xrsession-xr-device
         type: dfn; text: requestAnimationFrame()
@@ -295,7 +295,7 @@ Some examples of interacting with the user directly are:
 1. Displaying a permission prompt that allows the user to select how fine-grained information will be exposed to the site. Mock of such prompt can be seen below.
 
 <p align="center">
-  <img src="img/permission-mock.png"></img>
+  <img src="img/permission-mock.png">
 </p>
 
 2. Displaying a series of permission prompts that would take into consideration various levels of user consent needed in order to create a session with the requested and optional features provided by the application to {{XRSystem/requestSession()}} call.
@@ -309,7 +309,7 @@ User Agents should consider re-using permissions UI (or permissions granted to t
 Privacy indicators {#privacy-indicators}
 ------------------
 
-The user agent MUST display a privacy indicator every time an {{XRSession}} with [=camera-access=] has been created and has not yet [=XRSession/ended=]. If it ever becomes possible to modify a [=XRSession/set of granted features=] of a session after a session has been created, the indicator SHOULD be displayed for at least as long as the [=camera-access=] feature descriptor is [=list/contain|contained=] in the [=XRSession/set of granted features=] of the session.
+The user agent MUST display a privacy indicator every time an {{XRSession}} with [=camera-access=] has been created and has not yet {{XRSession/ended}}. If it ever becomes possible to modify a [=XRSession/set of granted features=] of a session after a session has been created, the indicator SHOULD be displayed for at least as long as the [=camera-access=] feature descriptor is [=list/contain|contained=] in the [=XRSession/set of granted features=] of the session.
 
 <section class="non-normative-remainder">
 


### PR DESCRIPTION
Fixes one bikshed error that `img` tags are self closing and don't need a closing tag (doing <img="foo..." /> also generated an error.
Fixes one link error for "powerful feature" which per the core spec appears to need to just be linked from `spec:permissions` instead of `spec:permissions-1`.
Fixes the link for XRSession/ended to avoid a link error attempting to link with the CSS spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/raw-camera-access/pull/25.html" title="Last updated on Dec 11, 2025, 9:55 PM UTC (1e6bb6a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/raw-camera-access/25/7a7cf58...1e6bb6a.html" title="Last updated on Dec 11, 2025, 9:55 PM UTC (1e6bb6a)">Diff</a>